### PR TITLE
support polyline culling for increased performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Add it in you FlutterMap and configure it using `TappablePolylineLayerOptions`.
           subdomains: ['a', 'b', 'c'],
         ),
         TappablePolylineLayerOptions(
+          // Will only render visible polylines, increasing performance
+          polylineCulling: true,
           polylines: [
             TaggedPolyline(
               tag: "My Polyline", // An optional tag to distinguish polylines in callback

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -77,15 +77,19 @@ class _MyHomePageState extends State<MyHomePage> {
             urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             subdomains: ['a', 'b', 'c'],
           ),
-          TappablePolylineLayerOptions(polylines: [
-            TaggedPolyline(
-              tag: "My Polyline",
-              // An optional tag to distinguish polylines in callback
-              points: getPoints(),
-              color: Colors.red,
-              strokeWidth: 3.0,
-            ),
-          ], onTap: (TaggedPolyline polyline) => print(polyline.tag))
+          TappablePolylineLayerOptions(
+              // Will only render visible polylines, increasing performance
+              polylineCulling: true,
+              polylines: [
+                TaggedPolyline(
+                  tag: "My Polyline",
+                  // An optional tag to distinguish polylines in callback
+                  points: getPoints(),
+                  color: Colors.red,
+                  strokeWidth: 3.0,
+                ),
+              ],
+              onTap: (TaggedPolyline polyline) => print(polyline.tag))
         ],
       ),
     );

--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -1,9 +1,8 @@
 library flutter_map_tappable_polyline;
 
-import 'package:flutter/material.dart';
-import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/plugin_api.dart';
 
 class TappablePolylineMapPlugin extends MapPlugin {
   bool supportsLayer(LayerOptions options) =>
@@ -25,7 +24,7 @@ class TappablePolylineLayerOptions extends PolylineLayerOptions {
       rebuild,
       this.onTap,
       this.pointerDistanceTolerance = 15,
-      polylineCulling})
+      polylineCulling = false})
       : super(rebuild: rebuild, polylineCulling: polylineCulling);
 }
 

--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -1,8 +1,9 @@
 library flutter_map_tappable_polyline;
 
+import 'package:flutter/material.dart';
+import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/plugin_api.dart';
 
 class TappablePolylineMapPlugin extends MapPlugin {
   bool supportsLayer(LayerOptions options) =>
@@ -14,7 +15,7 @@ class TappablePolylineMapPlugin extends MapPlugin {
   }
 }
 
-class TappablePolylineLayerOptions extends LayerOptions {
+class TappablePolylineLayerOptions extends PolylineLayerOptions {
   final List<TaggedPolyline> polylines;
   final double pointerDistanceTolerance;
   Function onTap = (TaggedPolyline polyline) {};
@@ -23,8 +24,9 @@ class TappablePolylineLayerOptions extends LayerOptions {
       {this.polylines = const [],
       rebuild,
       this.onTap,
-      this.pointerDistanceTolerance = 15})
-      : super(rebuild: rebuild);
+      this.pointerDistanceTolerance = 15,
+      polylineCulling})
+      : super(rebuild: rebuild, polylineCulling: polylineCulling);
 }
 
 class TaggedPolyline extends Polyline {
@@ -74,6 +76,13 @@ class TappablePolylineLayer extends StatelessWidget {
       builder: (BuildContext context, _) {
         for (var polylineOpt in polylineOpts.polylines) {
           polylineOpt.offsets.clear();
+
+          if (polylineOpts.polylineCulling &&
+              !polylineOpt.boundingBox.isOverlapping(map.bounds)) {
+            // Skip this polyline as it is not within the current map bounds (i.e not visible on screen)
+            continue;
+          }
+
           var i = 0;
           for (var point in polylineOpt.points) {
             var pos = map.project(point);


### PR DESCRIPTION
Got it working 👍 - simply looked into the implementation of polylineculling on a normal polyline and copied it into PolylineLayer. It is not very DRY, but i guess it is okay since we are not able to directly do any changes on the flutter_map implementation.
 ```
if (polylineOpts.polylineCulling &&
          !polylineOpt.boundingBox.isOverlapping(map.bounds)) {
           // Skip this polyline as it is not within the current map bounds (i.e not visible on screen)
          continue;
}
```
