### PR TITLE
[3.x] Overlapping line support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,7 +88,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   // An optional tag to distinguish polylines in callback
                   points: getPoints(0),
                   color: Colors.red,
-                  strokeWidth: 3.0,
+                  strokeWidth: 9.0,
                 ),
                 TaggedPolyline(
                   tag: 'My 2nd Polyline',
@@ -97,8 +97,16 @@ class _MyHomePageState extends State<MyHomePage> {
                   color: Colors.black,
                   strokeWidth: 3.0,
                 ),
+                TaggedPolyline(
+                  tag: 'My 3rd Polyline',
+                  // An optional tag to distinguish polylines in callback
+                  points: getPoints(0),
+                  color: Colors.blue,
+                  strokeWidth: 3.0,
+                ),
               ],
-              onTap: (TaggedPolyline polyline) => print(polyline.tag),
+              onTap: (polylines) => print('Tapped: ' +
+                  polylines.map((polyline) => polyline.tag).join(',')),
               onMiss: () {
                 print('No polyline was tapped');
               })

--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -30,10 +30,11 @@ class TappablePolylineLayerOptions extends PolylineLayerOptions {
   final double pointerDistanceTolerance;
 
   /// The callback to call when a polyline was hit by the tap
-  Function? onTap = (TaggedPolyline polyline) {};
+  void Function(List<TaggedPolyline>)? onTap =
+      (List<TaggedPolyline> polyline) {};
 
   /// The optional callback to call when no polyline was hit by the tap
-  Function? onMiss = () {};
+  void Function()? onMiss = () {};
 
   /// The ability to render only polylines in current view bounds
   @override

--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -153,10 +153,8 @@ class TappablePolylineLayer extends StatelessWidget {
 
   void _handlePolylineTap(
       TapUpDetails details, Function? onTap, Function? onMiss) {
-    var hit = false;
-
     // We might hit close to multiple polylines. We will therefore keep a reference to these in this map.
-    Map<double, TaggedPolyline> candidates = {};
+    Map<double, List<TaggedPolyline>> candidates = {};
 
     // Calculating taps in between points on the polyline. We
     // iterate over all the segments in the polyline to find any
@@ -206,14 +204,14 @@ class TappablePolylineLayer extends StatelessWidget {
         if (height < polylineOpts.pointerDistanceTolerance &&
             lengthDToOriginalSegment < polylineOpts.pointerDistanceTolerance) {
           var minimum = min(height, lengthDToOriginalSegment);
-          candidates[minimum] = currentPolyline as TaggedPolyline;
 
-          hit = true;
+          candidates[minimum] ??= <TaggedPolyline>[];
+          candidates[minimum]!.add(currentPolyline as TaggedPolyline);
         }
       }
     }
 
-    if (hit) {
+    if (candidates.isNotEmpty) {
       // We look up in the map of distances to the tap, and choose the shortest one.
       var closestToTapKey = candidates.keys.reduce(min);
       onTap!(candidates[closestToTapKey]);


### PR DESCRIPTION
Added support for overlapping lines. This will change the signature of the `onTap` callback.