### PR TITLE
[3.x] Add LayerWidget

### DIFF
--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -75,6 +75,18 @@ class TaggedPolyline extends Polyline {
             isDotted: isDotted);
 }
 
+class TappablePolylineLayerWidget extends StatelessWidget {
+  final TappablePolylineLayerOptions options;
+
+  TappablePolylineLayerWidget({Key? key, required this.options}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.maybeOf(context)!;
+    return TappablePolylineLayer(options, mapState, mapState.onMoved);
+  }
+}
+
 class TappablePolylineLayer extends StatelessWidget {
   /// The options allowing tappable polyline tweaks
   final TappablePolylineLayerOptions polylineOpts;

--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -75,6 +75,7 @@ class TaggedPolyline extends Polyline {
             isDotted: isDotted);
 }
 
+// A widget to render the layer as a FlutterMap.children
 class TappablePolylineLayerWidget extends StatelessWidget {
   final TappablePolylineLayerOptions options;
 


### PR DESCRIPTION
Added a LayerWidget to be able to create the Layer in FlutterMap.children as it is done for example in the MarkerPopup plugin: https://github.com/rorystephenson/flutter_map_marker_popup/blob/master/example/lib/simple_map_with_popups.dart#L27