### PR TITLE
Remove unnecessary import

### DIFF
--- a/lib/flutter_map_tappable_polyline.dart
+++ b/lib/flutter_map_tappable_polyline.dart
@@ -3,7 +3,6 @@ library flutter_map_tappable_polyline;
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:positioned_tap_detector_2/positioned_tap_detector_2.dart';


### PR DESCRIPTION
Based on pub.dev static analysis score

INFO: The import of 'package:flutter_map/flutter_map.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter_map/plugin_api.dart'.